### PR TITLE
Implement additions to initramfs-tools to support loop mounted root

### DIFF
--- a/config/includes.chroot/etc/initramfs-tools/conf.d/loop_options
+++ b/config/includes.chroot/etc/initramfs-tools/conf.d/loop_options
@@ -1,0 +1,19 @@
+export LOOPROOT=
+export LOOPFSTYPE=ntfs-3g
+export LOOPSRC=
+
+for x in $(cat /proc/cmdline); do
+	case $x in
+	looproot=*)
+		LOOPROOT=${x#looproot=}
+		case $LOOPROOT in
+		UUID=*)
+			LOOPROOT="/dev/disk/by-uuid/${LOOPROOT#UUID=}"
+			;;
+		esac
+		;;
+	loopsrc=*)
+		LOOPSRC=${x#loopsrc=}
+		;;
+	esac
+done	

--- a/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+case "${1}" in
+	prereqs)
+		echo ""
+		exit 0
+		;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+copy_exec /sbin/kpartx /sbin
+
+exit 0

--- a/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+case "${1}" in
+	prereqs)
+		echo "ntfs_3g"
+		exit 0
+		;;
+esac
+
+if [ "x${LOOPROOT}" != "x" ]; then
+	sleep 2
+	modprobe loop
+	mkdir -p /mnt/looproot
+	mount -t ntfs-3g ${LOOPROOT} /mnt/looproot
+	losetup /dev/loop0 /mnt/looproot/${LOOPSRC}
+	kpartx -a /dev/loop0
+
+	mkdir -p /run/sendsigs.omit.d
+	pidof mount.ntfs-3g >> /run/sendsigs.omit.d/ntfs-3g
+fi
+
+exit 0


### PR DESCRIPTION
Two kernel command line parameters are parsed and used:
looproot= specifies the block device that contains a loop mountable
drive, UUID is supported for this option
loopsrc= specifies the file on the looproot that will be used for loop
setup; this should be a _full_ disk image including MBR

looproot/loopsrc will be setup as /dev/loop0 and its partitions will be
available through /dev/mapper/loop0pX, so to use the first partition as
the real root, one should specify root=/dev/mapper/loop0p1

ntfs-3g is hard coded for the looproot, and the appropriate
sendsigs.omit files are recorded for clean reboots, as these were not
being set by the provided local-bottom scripts.

@Motiejus, please review. I have tested the procedure in general, but don't know if simply including these files under includes.chroot will work. We might have to add a hook to regenerate initramfs.
