### PR TITLE
Fetching of loop root drive from the network.

### DIFF
--- a/config/includes.chroot/etc/initramfs-tools/conf.d/loop_options
+++ b/config/includes.chroot/etc/initramfs-tools/conf.d/loop_options
@@ -1,6 +1,7 @@
 export LOOPROOT=
 export LOOPFSTYPE=ntfs-3g
 export LOOPSRC=
+export LOOPGET=
 
 for x in $(cat /proc/cmdline); do
 	case $x in
@@ -14,6 +15,9 @@ for x in $(cat /proc/cmdline); do
 		;;
 	loopsrc=*)
 		LOOPSRC=${x#loopsrc=}
+		;;
+	loopget=*)
+		LOOPGET=${x#loopget=}
 		;;
 	esac
 done	

--- a/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
@@ -12,5 +12,6 @@ esac
 copy_exec /sbin/kpartx /sbin/
 copy_exec /usr/bin/wget /usr/bin/
 copy_exec /usr/bin/xz /usr/bin/
+copy_exec /bin/gzip /bin/
 
 exit 0

--- a/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/hooks/loop_mount
@@ -9,6 +9,8 @@ case "${1}" in
 esac
 
 . /usr/share/initramfs-tools/hook-functions
-copy_exec /sbin/kpartx /sbin
+copy_exec /sbin/kpartx /sbin/
+copy_exec /usr/bin/wget /usr/bin/
+copy_exec /usr/bin/xz /usr/bin/
 
 exit 0

--- a/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 case "${1}" in
 	prereqs)
 		echo "ntfs_3g"
@@ -10,39 +12,114 @@ esac
 . /scripts/functions
 
 if [ "x${LOOPROOT}" != "x" ]; then
+	_log_msg "Will attempt to use ${LOOPSRC} from ${LOOPROOT} as loop mounted drive"
+
 	lprootp=/mnt/looproot
 	lprootd=/dev/loop0
 
 	sleep 2
 	modprobe loop
 	mkdir -p ${lprootp}
-	mount -t ntfs-3g ${LOOPROOT} ${lprootp}
 
-	if [ "x${LOOPGET}" != "x" ]; then
+	log_begin_msg "mounting ${LOOPROOT}"
+	mount -t ntfs-3g ${LOOPROOT} ${lprootp} || {
+		rc=$?
+		log_failure_msg "mounting failed ${rc}"
+		exit ${rc}
+	}
+	log_end_msg
+
+	loopfile=${lprootp}/${LOOPSRC}
+	if [ -f ${loopfile} ]; then
+		log_success_msg "loop drive file exists and is $(stat -c %s ${loopfile}) bytes"
+	elif [ "x${LOOPGET}" != "x" ]; then
+		_log_msg "loop drive file does not exist, will attempt to fetch it from ${LOOPGET}"
+
+		set +e
+		log_begin_msg "configuring networking"
 		configure_networking
+		log_end_msg
+		set -e
+
+		log_begin_msg "starting wget -P ${lprootp} -c ${LOOPGET}"
 		/usr/bin/wget -P ${lprootp} -c ${LOOPGET} || {
-			echo wget failed $?
-			read
-			panic
+			rc=$?
+			log_failure_msg "wget failed ${rc}"
+			exit ${rc}
 		}
+		log_end_msg
 
 		outfile=${LOOPGET##http*/}
-		outext=${outfile##*.}
-		if [ "${outext}" = "xz" ]; then
-			/usr/bin/xz -d ${lprootp}/${outfile}
+		out_ext=${outfile##*.}
+		out_with_stripped_ext=${outfile%.*}
+
+		_log_msg "Assuming that we fetched file ${outfile}"
+		case ${out_ext} in
+		xz)
+			log_begin_msg "decompress xz'ed image"
+			/usr/bin/xz --keep -v -d ${lprootp}/${outfile} || {
+				rc=$?
+				log_failure_msg "xz failed ${rc}"
+				exit ${rc}
+			}
+			log_end_msg
+			;;
+		gz)
+			log_begin_msg "decompress gzip'ed image"
+			/bin/gzip -v -d ${lprootp}/${outfile} > ${lprootp}/${out_with_stripped_ext} || {
+				rc=$?
+				log_failure_msg "gzip failed ${rc}"
+				exit ${rc}
+			}
+			log_end_msg
+			;;
+		raw)
+			_log_msg "fetched file with .raw extension, nothing else to do"
+			;;
+		*)
+			log_failure_msg "fetched file with unsupported extension, failing"
+			exit 1
+			;;
+		esac
+
+		if [ ! -f ${loopfile} ]; then
+			log_failure_msg "loop drive file still does not exist"
+			exit 1
 		fi
+
 		unset outfile
-		unset outext
+		unset out_ext
+		unset out_with_stripped_ext
+	else
+		log_failure_msg "loop drive file does not exist and no fetch source configured"
+		exit 1
 	fi
 
-	losetup ${lprootd} ${lprootp}/${LOOPSRC}
-	kpartx -a ${lprootd}
+	log_begin_msg "setting up loop device ${lprootd} from ${loopfile}"
+	losetup ${lprootd} ${loopfile} || {
+		rc=$?
+		log_failure_msg "losetup failed ${rc}"
+		exit ${rc}
+	}
+	log_end_msg
 
+	log_begin_msg "probing loop device for partitions"
+	kpartx -a ${lprootd} || {
+		rc=$?
+		log_failure_msg "kpartx failed ${rc}"
+		exit ${rc}
+	}
+	log_end_msg
+
+	_log_msg "recording ntfs-3g driver in no-kill list"
 	mkdir -p /run/sendsigs.omit.d
 	pidof mount.ntfs-3g >> /run/sendsigs.omit.d/ntfs-3g
 
+	unset loopfile
 	unset lprootp
 	unset lprootd
+
+	log_success_msg "setup loop mounted root"
 fi
 
 exit 0

--- a/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
+++ b/config/includes.chroot/etc/initramfs-tools/scripts/init-premount/loop_mount
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 case "${1}" in
 	prereqs)
 		echo "ntfs_3g"
@@ -9,16 +7,42 @@ case "${1}" in
 		;;
 esac
 
+. /scripts/functions
+
 if [ "x${LOOPROOT}" != "x" ]; then
+	lprootp=/mnt/looproot
+	lprootd=/dev/loop0
+
 	sleep 2
 	modprobe loop
-	mkdir -p /mnt/looproot
-	mount -t ntfs-3g ${LOOPROOT} /mnt/looproot
-	losetup /dev/loop0 /mnt/looproot/${LOOPSRC}
-	kpartx -a /dev/loop0
+	mkdir -p ${lprootp}
+	mount -t ntfs-3g ${LOOPROOT} ${lprootp}
+
+	if [ "x${LOOPGET}" != "x" ]; then
+		configure_networking
+		/usr/bin/wget -P ${lprootp} -c ${LOOPGET} || {
+			echo wget failed $?
+			read
+			panic
+		}
+
+		outfile=${LOOPGET##http*/}
+		outext=${outfile##*.}
+		if [ "${outext}" = "xz" ]; then
+			/usr/bin/xz -d ${lprootp}/${outfile}
+		fi
+		unset outfile
+		unset outext
+	fi
+
+	losetup ${lprootd} ${lprootp}/${LOOPSRC}
+	kpartx -a ${lprootd}
 
 	mkdir -p /run/sendsigs.omit.d
 	pidof mount.ntfs-3g >> /run/sendsigs.omit.d/ntfs-3g
+
+	unset lprootp
+	unset lprootd
 fi
 
 exit 0


### PR DESCRIPTION
An additional kernel command line parameter, LOOPGET, can be specified,
which, if found, will make the init process fetch this URL and place it in
LOOPROOT. If the fetched file is xz-compressed, it is decompressed before
continuing. Current assumption is that the name of the fetched file (minus
the optional .xz extension) must match that of LOOPSRC.