### PR TITLE
Using debian Jessie base image instead of Wheezy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ For organizers: actual production scripts are in internal SVN under folder
 Changelog
 ---------
 
+* 0.3.0 - change to Jessie base image
 * 0.1.2 - add geany-plugins (for debugger support in geany IDE).
 * 0.1.1 - switch back to sysvinit due to systemd incompleteness (see git log).
   Testable version.

--- a/config/binary
+++ b/config/binary
@@ -26,7 +26,7 @@ LB_BOOTAPPEND_LIVE_FAILSAFE="boot=live config memtest noapic noapm nodma nomce n
 
 # $LB_BOOTLOADER: set bootloader
 # (Default: syslinux)
-LB_BOOTLOADER="syslinux"
+LB_BOOTLOADER="systemd"
 
 # $LB_CHECKSUMS: set checksums
 # (Default: md5)
@@ -51,7 +51,7 @@ LB_DEBIAN_INSTALLER="live"
 
 # $LB_DEBIAN_INSTALLER_DISTRIBUTION: set debian-installer suite
 # (Default: empty)
-LB_DEBIAN_INSTALLER_DISTRIBUTION="wheezy"
+LB_DEBIAN_INSTALLER_DISTRIBUTION="jessie"
 
 # $LB_DEBIAN_INSTALLER_PRESEEDFILE: set debian-installer preseed filename/url
 # (Default: )
@@ -71,7 +71,7 @@ LB_HDD_LABEL="DEBIAN_LIVE"
 
 # $LB_HDD_SIZE: set hdd filesystem size
 # (Default: 10000)
-LB_HDD_SIZE="10000"
+LB_HDD_SIZE="7000"
 
 # $LB_ISO_APPLICATION: set iso author
 # (Default: Debian Live)
@@ -86,8 +86,8 @@ LB_ISO_PREPARER="live-build $VERSION; http://packages.qa.debian.org/live-build"
 LB_ISO_PUBLISHER="Debian Live project; http://live.debian.net/; debian-live@lists.debian.org"
 
 # $LB_ISO_VOLUME: set iso volume (max 32 chars)
-# (Default: Debian wheezy $(date +%Y%m%d-%H:%M))
-LB_ISO_VOLUME="Debian wheezy $(date +%Y%m%d-%H:%M)"
+# (Default: Debian jessie $(date +%Y%m%d-%H:%M))
+LB_ISO_VOLUME="Debian jessie $(date +%Y%m%d-%H:%M)"
 
 # $LB_JFFS2_ERASEBLOCK: set jffs2 eraseblock size
 # (Default: unset)

--- a/config/bootstrap
+++ b/config/bootstrap
@@ -6,15 +6,15 @@ LB_ARCHITECTURES="i386"
 
 # $LB_DISTRIBUTION: select distribution to use
 # (Default: wheezy)
-LB_DISTRIBUTION="wheezy"
+LB_DISTRIBUTION="jessie"
 
 # $LB_PARENT_DISTRIBUTION: select parent distribution to use
 # (Default: wheezy)
-LB_PARENT_DISTRIBUTION="wheezy"
+LB_PARENT_DISTRIBUTION="jessie"
 
 # $LB_PARENT_DEBIAN_INSTALLER_DISTRIBUTION: select parent distribution for debian-installer to use
 # (Default: wheezy)
-LB_PARENT_DEBIAN_INSTALLER_DISTRIBUTION="wheezy"
+LB_PARENT_DEBIAN_INSTALLER_DISTRIBUTION="jessie"
 
 # $LB_PARENT_MIRROR_BOOTSTRAP: set parent mirror to bootstrap from
 # (Default: http://http.debian.net/debian)

--- a/config/build
+++ b/config/build
@@ -1,0 +1,10 @@
+[Image]
+Architecture: i386
+Archive-Areas: main contrib non-free
+Distribution: jessie
+Mirror-Bootstrap: http://ftp.debian.org/debian/
+
+[FIXME]
+Configuration-Version: 4.0.3
+Name: live-image
+Type: iso

--- a/config/chroot
+++ b/config/chroot
@@ -42,4 +42,5 @@ LB_UPDATES="true"
 
 # $LB_BACKPORTS: enable backports updates
 # (Default: false)
-LB_BACKPORTS="false"
+# codeblocks package is only in jessie-backports
+LB_BACKPORTS="true"

--- a/config/includes.chroot/etc/skel/Desktop/Code/emacs23.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/Code/emacs23.desktop
@@ -1,1 +1,0 @@
-/usr/share/applications/emacs23.desktop

--- a/config/includes.chroot/etc/skel/Desktop/Code/emacs24.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/Code/emacs24.desktop
@@ -1,0 +1,1 @@
+/usr/share/applications/emacs24.desktop

--- a/config/includes.chroot/etc/skel/Desktop/Code/gedit.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/Code/gedit.desktop
@@ -1,1 +1,1 @@
-/usr/share/applications/gedit.desktop
+/usr/share/applications/org.gnome.gedit.desktop

--- a/config/includes.chroot/etc/skel/Desktop/Code/lazarus-0.9.30.4.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/Code/lazarus-0.9.30.4.desktop
@@ -1,1 +1,0 @@
-/usr/share/applications/lazarus-0.9.30.4.desktop

--- a/config/includes.chroot/etc/skel/Desktop/Code/lazarus-1.2.4.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/Code/lazarus-1.2.4.desktop
@@ -1,0 +1,1 @@
+/usr/share/applications/lazarus-1.2.4.desktop

--- a/config/includes.chroot/etc/skel/Desktop/Docs/FP.html
+++ b/config/includes.chroot/etc/skel/Desktop/Docs/FP.html
@@ -1,1 +1,1 @@
-/usr/share/doc/fp-docs/2.6.0/fpctoc.html
+/usr/share/doc/fp-docs/2.6.4/fpctoc.html

--- a/config/includes.chroot/etc/skel/Desktop/Docs/GCC.html
+++ b/config/includes.chroot/etc/skel/Desktop/Docs/GCC.html
@@ -1,1 +1,1 @@
-/usr/share/doc/gcc-4.7-doc/gcc.html
+/usr/share/doc/gcc-4.9-doc/gcc.html

--- a/config/includes.chroot/etc/skel/Desktop/Docs/c-reference.html
+++ b/config/includes.chroot/etc/skel/Desktop/Docs/c-reference.html
@@ -1,1 +1,0 @@
-/usr/share/doc/c-cpp-reference/html/C/cref.html

--- a/config/includes.chroot/etc/skel/Desktop/Docs/cplusplus-reference.html
+++ b/config/includes.chroot/etc/skel/Desktop/Docs/cplusplus-reference.html
@@ -1,1 +1,0 @@
-/usr/share/doc/c-cpp-reference/html/CPLUSPLUS/cref.html

--- a/config/includes.chroot/etc/skel/Desktop/Docs/cppreference.html
+++ b/config/includes.chroot/etc/skel/Desktop/Docs/cppreference.html
@@ -1,0 +1,1 @@
+/usr/share/cppreference/doc/html/en/index.html

--- a/config/package-lists/liox.list
+++ b/config/package-lists/liox.list
@@ -1,31 +1,22 @@
-# Desktop stuff
 lxde task-laptop xarchiver feh gpicview scrot evince
 iceweasel system-config-printer conky
 
-# Kernel, video
 xserver-xorg-video-all virtualbox-guest-x11
 
-# Desktop editors, IDEs
 vim-gtk joe lazarus gedit scite geany geany-plugins leafpad codeblocks
 eclipse-cdt kdevelop
 
-# Console utilities/console editors
-zsh mc emacs nano git mercurial ipython
+zsh mc emacs nano git ipython
 
-# Compilers, debuggers, profilers
 make gcc g++ fpc gdb ddd valgrind
 
-# Misc programming languages
-lua5.2 ruby python python3 clang
+ruby python python3
 
-# Network and system utilities
 strace lsof tree nmap netcat tightvncserver curl dnsutils telnet screen
 iotop tmux htop x11vnc kpartx autossh tsocks units openssh-server mlocate
-bridge-utils bash-completion rfkill apt-file
+bridge-utils bash-completion rfkill apt-file ntp locales
 
-# Documentation
-stl-manual gdb-doc gcc-doc glibc-doc manpages manpages-posix-dev fp-docs
-c-cpp-reference
+stl-manual gdb-doc gcc-doc manpages fp-docs
+cppreference-doc-en-html
 
-# Hangman
 bsdgames


### PR DESCRIPTION
* Uses Jessie base image for ISO construction
* Fixed some broken links on preseeded desktop to better correspond with current package versions.