### PR TITLE
Remove text/html mimetype from geany.

### DIFF
--- a/config/hooks/geany_mimetype.chroot
+++ b/config/hooks/geany_mimetype.chroot
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+sed -i -e 's/text\/html;//' /usr/share/applications/geany.desktop
+update-desktop-database
+


### PR DESCRIPTION
Fixes issue of text/html files being associated with geany instead of installed browser.