### PR TITLE
Tweaks for lightdm greeter and LXDE fonts.

### DIFF
--- a/config/includes.chroot/etc/lightdm/lightdm-gtk-greeter.conf
+++ b/config/includes.chroot/etc/lightdm/lightdm-gtk-greeter.conf
@@ -1,0 +1,33 @@
+#
+# background = Background file to use, either an image path or a color (e.g. #772953)
+# theme-name = GTK+ theme to use
+# icon-theme-name = Icon theme to use
+# font-name = Font to use
+# xft-antialias = Whether to antialias Xft fonts (true or false)
+# xft-dpi = Resolution for Xft in dots per inch (e.g. 96)
+# xft-hintstyle = What degree of hinting to use (none, slight, medium, or hintfull)
+# xft-rgba = Type of subpixel antialiasing (none, rgb, bgr, vrgb or vbgr)
+# show-indicators = semi-colon ";" separated list of allowed indicator modules. Built-in indicators include "~a11y", "~language", "~session", "~power". Unity indicators can be represented by short name (e.g. "sound", "power"), service file name, or absolute path
+# show-clock (true or false)
+# clock-format = strftime-format string, e.g. %H:%M
+# keyboard = command to launch on-screen keyboard
+# position = main window position: x y
+# default-user-image = Image used as default user icon, path or #icon-name
+# screensaver-timeout = Timeout (in seconds) until the screen blanks when the greeter is called as lockscreen
+# 
+[greeter]
+background=#000000
+default-user-image=/usr/share/images/desktop-base/lmio_logo.jpg
+theme-name=Adwaita
+#icon-theme-name=
+#font-name=
+xft-antialias=true
+#xft-dpi=
+xft-hintstyle=hintfull
+xft-rgba=rgb
+show-indicators=~language;~session;~power
+#show-clock=
+#clock-format=
+#keyboard=
+#position=
+#screensaver-timeout=

--- a/config/includes.chroot/etc/xdg/pcmanfm/LXDE/pcmanfm.conf
+++ b/config/includes.chroot/etc/xdg/pcmanfm/LXDE/pcmanfm.conf
@@ -7,7 +7,7 @@ wallpaper_mode=3
 wallpaper=/etc/alternatives/desktop-background
 desktop_fg=#ffffff
 desktop_bg=#000000
-desktop_shadow=#ffffff
+desktop_shadow=#000000
 
 [ui]
 always_show_tabs=0


### PR DESCRIPTION
- Replaces white shadows in LXDE with black to better match with wallpaper
- Replaces default debian greeter image with black background to better match the wallpaper
